### PR TITLE
Documentation and imports fix

### DIFF
--- a/cookiecutter/extensions.py
+++ b/cookiecutter/extensions.py
@@ -4,12 +4,7 @@
 
 import json
 import string
-
-try:
-    # Python 3.6 and above
-    from secrets import choice
-except ImportError:
-    from random import choice
+from random import choice
 
 from jinja2.ext import Extension
 
@@ -34,7 +29,6 @@ class RandomStringExtension(Extension):
         super(RandomStringExtension, self).__init__(environment)
 
         def random_ascii_string(length, punctuation=False):
-            corpus = string.ascii_letters
             if punctuation:
                 corpus = "".join((string.ascii_letters, string.punctuation))
             else:

--- a/cookiecutter/extensions.py
+++ b/cookiecutter/extensions.py
@@ -4,7 +4,11 @@
 
 import json
 import string
-from random import choice
+try:
+    # Python 3.6 and above
+    from secrets import choice
+except ImportError:
+    from random import choice
 
 from jinja2.ext import Extension
 

--- a/docs/advanced/template_extensions.rst
+++ b/docs/advanced/template_extensions.rst
@@ -27,7 +27,7 @@ Please note that Cookiecutter will **not** install any dependencies on its own!
 As a user you need to make sure you have all the extensions installed, before
 running Cookiecutter on a template that requires custom Jinja2 extensions.
 
-By default Cookiecutter includes the folllowing extensions:
+By default Cookiecutter includes the following extensions:
 
 - ``cookiecutter.extensions.JsonifyExtension``
 - ``cookiecutter.extensions.RandomStringExtension``
@@ -39,7 +39,7 @@ Jsonify extension
 The ``cookiecutter.extensions.JsonifyExtension`` extension provides a ``jsonify`` filter in templates
 that converts a Python object to JSON:
 
-.. code-block:: jinja2
+.. code-block:: jinja
 
     {% {'a': True} | jsonify %}
 
@@ -52,12 +52,14 @@ Would output:
 Random string extension
 ~~~~~~~~~~~~~~~~~~~~~~~
 
+*New in Cookiecutter 1.7*
+
 The ``cookiecutter.extensions.RandomStringExtension`` extension provides a ``random_ascii_string``
 method in templates that generates a random fixed-length string, optionally with punctuation.
 
-To generate a random 12 character string:
+Generate a random n-size character string. Example for n=12:
 
-.. code-block:: jinja2
+.. code-block:: jinja
 
     {{ random_ascii_string(12) }}
 
@@ -67,10 +69,10 @@ Outputs:
 
     bIIUczoNvswh
 
-The second argument controls if punctuation (``'!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~'``) should be
-present in the result:
+The second argument controls if punctuation and special characters
+``!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~`` should be present in the result:
 
-.. code-block:: jinja2
+.. code-block:: jinja
 
     {{ random_ascii_string(12, punctuation=True) }}
 


### PR DESCRIPTION
* Remove of different imports for different python versions. Reason: Cookiecutter is not crypto library + Time of creation template from cookie is random event by itself.
* Correct highlight name for ``jinja2`` templates is ``jinja``